### PR TITLE
Clean up build-essentials after installing them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM python:3.4.2-onbuild
+FROM python:3-slim
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY requirements.txt /usr/src/app/
+
+RUN apt-get update && \
+    apt-get install -y build-essential && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apt-get remove -y --purge build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY run.sh /usr/src/app/
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Flower Docker image
 [![](https://badge.imagelayers.io/tomologic/flower:latest.svg)](https://imagelayers.io/?images=tomologic/flower:latest)
+
 Flower is a web based tool for monitoring and administrating Celery clusters. Github repository: https://github.com/mher/flower
 
 # Usage


### PR DESCRIPTION
Reasoning: https://github.com/tomologic/python
