### PR TITLE
Apply hot-fix for Celery v4 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,11 @@ WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Temporary fix until a celery release is available incorporating
+# https://github.com/celery/celery/pull/3950
+COPY patches/celeryv4_flower_fix.patch /tmp/
+RUN cd /usr/local/lib/python3.6/site-packages/celery \
+ && patch -p1 < /tmp/celeryv4_flower_fix.patch
+
 COPY run.sh /usr/src/app/
 CMD ["/usr/src/app/run.sh"]

--- a/patches/celeryv4_flower_fix.patch
+++ b/patches/celeryv4_flower_fix.patch
@@ -1,0 +1,35 @@
+diff --git a/events/state.py b/events/state.py
+index effdaa6..c761e77 100644
+--- a/events/state.py
++++ b/events/state.py
+@@ -296,7 +296,7 @@ class Task(object):
+         self.children = WeakSet(
+             self.cluster_state.tasks.get(task_id)
+             for task_id in children or ()
+-            if task_id in self.cluster_state.tasks
++	    if self.cluster_state is not None and task_id in self.cluster_state.tasks
+         )
+         self._serializer_handlers = {
+             'children': self._serializable_children,
+@@ -384,11 +384,19 @@ class Task(object):
+ 
+     @cached_property
+     def parent(self):
+-        return self.parent_id and self.cluster_state.tasks[self.parent_id]
++        # issue github.com/mher/flower/issues/648
++        try:
++            return self.parent_id and self.cluster_state.tasks[self.parent_id]
++        except KeyError:
++            return None
+ 
+     @cached_property
+     def root(self):
+-        return self.root_id and self.cluster_state.tasks[self.root_id]
++        # issue github.com/mher/flower/issues/648
++        try:
++            return self.root_id and self.cluster_state.tasks[self.root_id]
++        except KeyError:
++            return None
+ 
+ 
+ class State(object):


### PR DESCRIPTION
Flower throws a stack trace and returns HTTP 500 when the /tasks
endpoint is being triggered. A defect that manifested after Celery went
from v3 to v4.

The following change is incorporated
https://github.com/celery/celery/pull/3950

To address the following issue:
https://github.com/mher/flower/issues/648